### PR TITLE
Fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ repo does not get bogged down with large genesis files and status updates.
 # Getting Started
 
 To get started with the latest testnet, see the
-[docs](https://cosmos.network/docs/gaia/join-testnet.html).
+[docs](https://hub.cosmos.network/docs/join-testnet.html).
 
 # Testnet Status
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v If adding a new genesis file, make sure you also 
v update the `latest` directory. This is so the SDK repo
v can always just link to `latest` in the docs :)
v    
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Duplicated new genesis file in `latest` directory
