### PR TITLE
Add details for consumer-1 chain

### DIFF
--- a/replicated-security/README.md
+++ b/replicated-security/README.md
@@ -14,13 +14,16 @@ This testnet includes the following:
 ### Live Chains
 
 * Provider: [`provider-1`](/replicated-security/provider-1/README.md)
-* Consumer: [`timeout-1`](/replicated-security/timeout-1/README.md) (Waiting to timeout on consumer `init_timeout_period`)
 * Consumer: [`timeout-2`](/replicated-security/timeout-2/README.md) (Waiting to timeout on `vsc_timeout_period`)
 * Consumer: [`timeout-3`](/replicated-security/timeout-2/README.md) (Waiting to timeout on `ccv_timeout_period`)
 
+### Stopped Chains
+
+* Consumer: [`timeout-1`](/replicated-security/timeout-1/README.md) (Timed out on provider `init_timeout_period`)
+
 ## Upcoming Events
 
-* 2023-01-26: `consumer-1` chain launch
+* 2023-01-26: [`consumer-1`](/replicated-security/consumer-1/README.md) chain launch
 * 2023-01-30: `slasher-1` chain launch
 
 See the [RS testnet schedule](SCHEDULE.md) for consumer chain launches and other planned events.

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -1,16 +1,17 @@
 ## Replicated Security Testnet Schedule
 
-| Date            | Type   | Description                                                                |
-|-----------------|--------|----------------------------------------------------------------------------|
-| January 30 2023 | Test   | Consumer chain `slasher-1` is stopped                                      |
-| January 30 2023 | Test   | Consumer chain `slasher-1` is created                                      |
-| January 26 2023 | Launch | Consumer chain `consumer-1` is created and relayer started                 |
+| Date            | Type   | Description                                                               |
+|-----------------|--------|---------------------------------------------------------------------------|
+| January 30 2023 | Test   | Consumer chain `slasher-1` is stopped                                     |
+| January 30 2023 | Test   | Consumer chain `slasher-1` is created                                     |
+| January 26 2023 | Launch | Consumer chain `consumer-1` is created and relayer started                |
 | January 26 2023 | Test   | Consumer chain `timeout-2` reaches `vsc_timeout_period` timeout and stops |
-| January 25 2023 | Test   | Consumer chain `timeout-3` reaches `ccv_timeout_period` timeout and stops |
-| January 24 2023 | Test   | Consumer chain `timeout-1` reaches `init_timeout_period` and stops      |
-| January 23 2023 | Test   | ✅ Relayer for `timeout-3` is stopped                                         |
-| January 23 2023 | Test   | ✅ Relayer for `timeout-2` is stopped                                         |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-3` is created and relayer started                  |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-2` is created and relayer started                  |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-1` is created                                      |
-
+| January 25 2023 | Test   | Consumer chain `timeout-3` stops |
+| January 25 2023 | Test   | Relayer for `timeout-3` is started again                                  |
+| January 25 2023 | Test   | Consumer chain `timeout-3` reaches `ccv_timeout_period` |
+| January 24 2023 | Test   | ✅Consumer chain `timeout-1` reaches `init_timeout_period` and stops       |
+| January 23 2023 | Test   | ✅ Relayer for `timeout-3` is stopped                                      |
+| January 23 2023 | Test   | ✅ Relayer for `timeout-2` is stopped                                      |
+| January 23 2023 | Launch | ✅ Consumer chain `timeout-3` is created and relayer started               |
+| January 23 2023 | Launch | ✅ Consumer chain `timeout-2` is created and relayer started               |
+| January 23 2023 | Launch | ✅ Consumer chain `timeout-1` is created                                   |

--- a/replicated-security/consumer-1/README.md
+++ b/replicated-security/consumer-1/README.md
@@ -1,7 +1,7 @@
 
 # `consumer-1` Chain Details
 
-> Status: **PROPOSAL PASSED | waiting for spawn time `2023-01-26 15:00 UTC`)**
+> Status: **PROPOSAL PASSED | waiting for spawn time `2023-01-26 15:00 UTC`**
 
 The `consumer-1` chain will be launched as a persistent dummy chain to test basic Interchain Security functionality.
 

--- a/replicated-security/consumer-1/README.md
+++ b/replicated-security/consumer-1/README.md
@@ -1,0 +1,81 @@
+
+# `consumer-1` Chain Details
+
+The `consumer-1` chain will be launched as a persistent dummy chain to test basic Interchain Security functionality.
+
+* **Chain-ID**: `consumer-1`
+* **denom**: `ucon`
+* **Spawn time**: `2023-01-26T15:00:00.000000Z`
+* **GitHub repo**: [cosmos/interchain-security](https://github.com/cosmos/interchain-security)
+* **Release**: [`v1.0.0-rc3`](https://github.com/cosmos/interchain-security/releases/tag/v1.0.0-rc3)
+* **Reference binary**: [consumer-1-linux-amd64](consumer-1-linux-amd64)
+* **Binary sha256sum**: `376cdbd3a222a3d5c730c9637454cd4dd925e2f9e2e0d0f3702fc922928583f1`
+* **Genesis file _without CCV state_:** [consumer-1-genesis-without-ccv.json](consumer-1-genesis-without-ccv.json), verify with `shasum -a 256 provider-1-genesis.json`
+* **SHA256 for genesis file _without CCV state_**: `d86d756e10118e66e6805e9cc476949da2e750098fcc7634fd0cc77f57a0b2b0`
+
+The following items are included in the consumer addition proposal:
+
+* Genesis file hash
+  * The SHA256 is used to verify against the genesis file (without CCV state) that the proposer has made available for review.
+  * The `consumer-1-genesis-without-ccv.json` file cannot be used to run the chain: it must be updated with the CCV (Cross Chain Validation) state after the spawn time is reached.
+  * The genesis file includes funds for a relayer and a faucet account, and `signed_blocks_window` has been set to `10000`.
+* Binary hash
+  * The `consumer-1-linux-amd64` binary is only provided to verify the SHA256. It was built with Interchain Security release [`v1.0.0-rc3`](https://github.com/cosmos/interchain-security/releases/tag/v1.0.0-rc3). You can generate the binary following the build instructions in that repo or using one of the scripts provided here.
+* Spawn time
+  * Even if a proposal passes, the CCV state will not be available from the provider chain until after the spawn time is reached.
+
+For more information regarding the consumer chain creation process, see [CCV: Overview and Basic Concepts](https://github.com/cosmos/ibc/blob/main/spec/app/ics-028-cross-chain-validation/overview_and_basic_concepts.md).
+
+## Endpoints
+
+Endpoints are exposed as subdomains for the sentry and snapshot nodes (described below) as follows:
+
+* `http://rpc.<node-name>.rs-testnet.polypore.xyz`
+* `http://rest.<node-name>.rs-testnet.polypore.xyz`
+* `http://grpc.<node-name>.rs-testnet.polypore.xyz`
+* `p2p.<node-name>.rs-testnet.polypore.xyz:26656`
+
+Sentries:
+
+1. `consumer-1-sentry-01.rs-testnet.polypore.xyz`
+2. `consumer-1-sentry-02.rs-testnet.polypore.xyz`
+
+Seed nodes:
+
+1. `08ec17e86dac67b9da70deb20177655495a55407@consumer-1-seed-01.rs-testnet.polypore.xyz:26656`
+2. `4ea6e56300a2f37b90e58de5ee27d1c9065cf871@consumer-1-seed-02.rs-testnet.polypore.xyz:26656`
+
+The following state sync nodes serve snapshots every 1000 blocks:
+
+1. `consumer-1-state-sync-01.rs-testnet.polypore.xyz`
+1. `consumer-1-state-sync-02.rs-testnet.polypore.xyz`
+
+## IBC Information
+
+Connections and channels will be posted here shortly after the chain launches.
+
+## How to Join
+
+### Before the Spawn Time is Reached
+
+The CCV state will not be available until the spawn time is reached. If you want to set up your node(s) before then, you can do the following:
+
+1. Run one of the provided bash scripts.
+2. Wait until the genesis file that includes the CCV state is published to this repo, shortly after the spawn time is reached. Alternatively, you can update the genesis file yourself following the commands listed in [this guide](https://github.com/hyphacoop/ics-testnets/blob/main/docs/Consumer-Chain-Start-Process.md).
+3. Replace the genesis.json file in your `consumer-1` node with the one that includes the CCV state.
+4. Enable and start the service created by the script.
+
+#### Bash Scripts
+
+The scripts provided in this repo will install `interchain-security-cd` and optionally set up a Cosmovisor service on your machine. 
+
+Run either one of the scripts provided to set up a `consumer-1` service:
+* `join-rs-consumer-1.sh` will create a `consumer-1` service.
+* `join-rs-consumer-1-cv.sh` will create a `cosmovisor` service.
+* Both scripts must be run either as root or from a sudoer account.
+* Both scripts will attempt to build a binary from the [cosmos/interchain-security] repo.
+
+### After the Spawn Time is Reached
+
+* The genesis file that includes the CCV state will be published here.
+* The bash scripts will be updated.

--- a/replicated-security/consumer-1/README.md
+++ b/replicated-security/consumer-1/README.md
@@ -1,6 +1,8 @@
 
 # `consumer-1` Chain Details
 
+> Status: **PROPOSAL PASSED | waiting for spawn time `2023-01-26 15:00 UTC`)**
+
 The `consumer-1` chain will be launched as a persistent dummy chain to test basic Interchain Security functionality.
 
 * **Chain-ID**: `consumer-1`
@@ -13,7 +15,7 @@ The `consumer-1` chain will be launched as a persistent dummy chain to test basi
 * **Genesis file _without CCV state_:** [consumer-1-genesis-without-ccv.json](consumer-1-genesis-without-ccv.json), verify with `shasum -a 256 provider-1-genesis.json`
 * **SHA256 for genesis file _without CCV state_**: `d86d756e10118e66e6805e9cc476949da2e750098fcc7634fd0cc77f57a0b2b0`
 
-The following items are included in the consumer addition proposal:
+The following items are included in the consumer addition [proposal](https://explorer.rs-testnet.polypore.xyz/provider-1/gov/5):
 
 * Genesis file hash
   * The SHA256 is used to verify against the genesis file (without CCV state) that the proposer has made available for review.

--- a/replicated-security/consumer-1/consumer-1-genesis-without-ccv.json
+++ b/replicated-security/consumer-1/consumer-1-genesis-without-ccv.json
@@ -1,0 +1,181 @@
+{
+  "genesis_time": "2023-01-24T21:07:05.657521033Z",
+  "chain_id": "consumer-1",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "22020096",
+      "max_gas": "-1",
+      "time_iota_ms": "1000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {}
+  },
+  "app_hash": "",
+  "app_state": {
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "cosmos19mkwu6ne284ufqgdqnv4k6cp0qqy9x0742p3d2",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "cosmos1vm9ahk8s5mgc6gaw79k3ugnh9c8zssk4a27725",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        }
+      ]
+    },
+    "authz": {
+      "authorization": []
+    },
+    "bank": {
+      "params": {
+        "send_enabled": [],
+        "default_send_enabled": true
+      },
+      "balances": [
+        {
+          "address": "cosmos19mkwu6ne284ufqgdqnv4k6cp0qqy9x0742p3d2",
+          "coins": [
+            {
+              "denom": "ucon",
+              "amount": "100000000000000"
+            }
+          ]
+        },
+        {
+          "address": "cosmos1vm9ahk8s5mgc6gaw79k3ugnh9c8zssk4a27725",
+          "coins": [
+            {
+              "denom": "ucon",
+              "amount": "100000000000000"
+            }
+          ]
+        }
+      ],
+      "supply": [],
+      "denom_metadata": []
+    },
+    "capability": {
+      "index": "1",
+      "owners": []
+    },
+    "ccvconsumer": {
+      "params": {
+        "enabled": false,
+        "blocks_per_distribution_transmission": "1000",
+        "distribution_transmission_channel": "",
+        "provider_fee_pool_addr_str": "",
+        "ccv_timeout_period": "2419200s",
+        "transfer_timeout_period": "3600s",
+        "consumer_redistribution_fraction": "0.75",
+        "historical_entries": "10000",
+        "unbonding_period": "1728000s"
+      },
+      "provider_client_id": "",
+      "provider_channel_id": "",
+      "new_chain": false,
+      "provider_client_state": null,
+      "provider_consensus_state": null,
+      "maturing_packets": [],
+      "initial_val_set": [],
+      "height_to_valset_update_id": [],
+      "outstanding_downtime_slashing": [],
+      "pending_consumer_packets": {
+        "list": []
+      },
+      "last_transmission_block_height": {
+        "height": "0"
+      }
+    },
+    "crisis": {
+      "constant_fee": {
+        "denom": "ucon",
+        "amount": "1000"
+      }
+    },
+    "evidence": {
+      "evidence": []
+    },
+    "feegrant": {
+      "allowances": []
+    },
+    "ibc": {
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "params": {
+          "allowed_clients": [
+            "06-solomachine",
+            "07-tendermint"
+          ]
+        },
+        "create_localhost": false,
+        "next_client_sequence": "0"
+      },
+      "connection_genesis": {
+        "connections": [],
+        "client_connection_paths": [],
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
+      },
+      "channel_genesis": {
+        "channels": [],
+        "acknowledgements": [],
+        "commitments": [],
+        "receipts": [],
+        "send_sequences": [],
+        "recv_sequences": [],
+        "ack_sequences": [],
+        "next_channel_sequence": "0"
+      }
+    },
+    "params": null,
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "10000",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000"
+      },
+      "signing_infos": [],
+      "missed_blocks": []
+    },
+    "transfer": {
+      "port_id": "transfer",
+      "denom_traces": [],
+      "params": {
+        "send_enabled": true,
+        "receive_enabled": true
+      }
+    },
+    "upgrade": {},
+    "vesting": {}
+  }
+}

--- a/replicated-security/consumer-1/join-rs-consumer-1-cv.sh
+++ b/replicated-security/consumer-1/join-rs-consumer-1-cv.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Set up a Cosmovisor service to join the consumer-1 chain.
+
+# Configuration
+# You should only have to modify the values in this block
+# * Keys
+#    The private validator key and node key operations must match those used in the provider-1 chain if you want to run a validator.
+# ***
+PRIV_VALIDATOR_KEY_FILE=~/priv_validator_key.json
+NODE_KEY_FILE=~/node_key.json
+NODE_HOME=~/.consumer-1
+NODE_MONIKER=consumer-1
+SERVICE_NAME=cv-consumer-1
+STATE_SYNC=false
+# ***
+
+CHAIN_BINARY='interchain-security-cd'
+CHAIN_ID=consumer-1
+SEEDS="08ec17e86dac67b9da70deb20177655495a55407@consumer-1-seed-01.rs-testnet.polypore.xyz:26656,4ea6e56300a2f37b90e58de5ee27d1c9065cf871@consumer-1-seed-02.rs-testnet.polypore.xyz:26656,"
+SYNC_RPC_1=http://consumer-1-state-sync-01.rs-testnet.polypore.xyz:26657
+SYNC_RPC_2=http://consumer-1-state-sync-02.rs-testnet.polypore.xyz:26657
+SYNC_RPC_SERVERS="$SYNC_RPC_1,$SYNC_RPC_2"
+
+# The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
+# GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/consumer-1/consumer-1-genesis.json
+
+# Install wget and jq
+sudo apt-get install curl jq wget -y
+
+# Install go 1.19.4
+echo "Installing go..."
+rm go*linux-amd64.tar.gz
+wget https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+
+# Install interchain-security-cd binary
+echo "Installing build-essential..."
+sudo apt install build-essential -y
+echo "Installing interchain-security-cd..."
+cd $HOME
+mkdir -p $HOME/go/bin
+rm -rf interchain-security
+git clone https://github.com/cosmos/interchain-security.git
+cd interchain-security
+git checkout v1.0.0-rc3
+make install
+export PATH=$PATH:$HOME/go/bin
+
+# Initialize home directory
+echo "Initializing $NODE_HOME..."
+rm -rf $NODE_HOME
+$CHAIN_BINARY config chain-id $CHAIN_ID --home $NODE_HOME
+$CHAIN_BINARY config keyring-backend test --home $NODE_HOME
+$CHAIN_BINARY config broadcast-mode block --home $NODE_HOME
+$CHAIN_BINARY init $NODE_MONIKER --chain-id $CHAIN_ID --home $NODE_HOME
+sed -i -e "/seeds =/ s^= .*^= \"$SEEDS\"^" $NODE_HOME/config/config.toml
+
+# Replace keys
+echo "Replacing keys..."
+cp $PRIV_VALIDATOR_KEY_FILE $NODE_HOME/config/priv_validator_key.json
+cp $NODE_KEY_FILE $NODE_HOME/config/node_key.json
+
+# Replace genesis file: only after the spawn time is reached
+# echo "Replacing genesis file..."
+# wget $GENESIS_URL -O genesis.json
+# mv genesis.json $NODE_HOME/config/genesis.json
+
+if $STATE_SYNC ; then
+    echo "Configuring state sync..."
+    CURRENT_BLOCK=$(curl -s $SYNC_RPC_1/block | jq -r '.result.block.header.height')
+    TRUST_HEIGHT=$[$CURRENT_BLOCK-1000]
+    TRUST_BLOCK=$(curl -s $SYNC_RPC_1/block\?height\=$TRUST_HEIGHT)
+    TRUST_HASH=$(echo $TRUST_BLOCK | jq -r '.result.block_id.hash')
+    sed -i -e '/enable =/ s/= .*/= true/' $NODE_HOME/config/config.toml
+    sed -i -e "/trust_height =/ s/= .*/= $TRUST_HEIGHT/" $NODE_HOME/config/config.toml
+    sed -i -e "/trust_hash =/ s/= .*/= \"$TRUST_HASH\"/" $NODE_HOME/config/config.toml
+    sed -i -e "/rpc_servers =/ s^= .*^= \"$SYNC_RPC_SERVERS\"^" $NODE_HOME/config/config.toml
+else
+    echo "Skipping state sync..."
+fi
+
+# Set up cosmovisor
+echo "Setting up cosmovisor..."
+mkdir -p $NODE_HOME/cosmovisor/genesis/bin
+cp $(which $CHAIN_BINARY) $NODE_HOME/cosmovisor/genesis/bin
+
+echo "Installing cosmovisor..."
+export BINARY=$NODE_HOME/cosmovisor/genesis/bin/$CHAIN_BINARY
+go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.3.0
+
+echo "Creating $SERVICE_NAME.service..."
+sudo rm /etc/systemd/system/$SERVICE_NAME.service
+sudo touch /etc/systemd/system/$SERVICE_NAME.service
+
+echo "[Unit]"                               | sudo tee /etc/systemd/system/$SERVICE_NAME.service
+echo "Description=Cosmovisor service"       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "User=$USER"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "ExecStart=$HOME/go/bin/cosmovisor run start --x-crisis-skip-assert-invariants --home $NODE_HOME" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Restart=always"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "RestartSec=3"                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Environment='DAEMON_NAME=$CHAIN_BINARY'"      | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Environment='DAEMON_HOME=$NODE_HOME'" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Environment='DAEMON_ALLOW_DOWNLOAD_BINARIES=true'" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Environment='DAEMON_RESTART_AFTER_UPGRADE=true'" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Environment='DAEMON_LOG_BUFFER_SIZE=512'" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "[Install]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "WantedBy=multi-user.target"           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+
+# Start service
+sudo systemctl daemon-reload
+
+# Enable and start the service after the genesis that includes the CCV state is in place
+# sudo systemctl enable $SERVICE_NAME.service
+# sudo systemctl start $SERVICE_NAME.service
+# sudo systemctl restart systemd-journald
+
+# Add go and gaiad to the path
+echo "Setting up paths for go and cosmovisor current bin..."
+echo "export PATH=$PATH:/usr/local/go/bin:$NODE_HOME/cosmovisor/current/bin" >> .profile
+
+echo "***********************"
+echo "To see the Cosmovisor log enter:"
+echo "journalctl -fu $SERVICE_NAME.service"
+echo "***********************"

--- a/replicated-security/consumer-1/join-rs-consumer-1.sh
+++ b/replicated-security/consumer-1/join-rs-consumer-1.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Set up a service to join the consumer-1 chain.
+
+# Configuration
+# You should only have to modify the values in this block
+# * Keys
+#    The private validator key and node key operations must match those used in the provider-1 chain if you want to run a validator.
+# ***
+PRIV_VALIDATOR_KEY_FILE=~/priv_validator_key.json
+NODE_KEY_FILE=~/node_key.json
+NODE_HOME=~/.consumer-1
+NODE_MONIKER=consumer-1
+SERVICE_NAME=consumer-1
+STATE_SYNC=false
+# ***
+
+CHAIN_BINARY='interchain-security-cd'
+CHAIN_ID=consumer-1
+SEEDS="08ec17e86dac67b9da70deb20177655495a55407@consumer-1-seed-01.rs-testnet.polypore.xyz:26656,4ea6e56300a2f37b90e58de5ee27d1c9065cf871@consumer-1-seed-02.rs-testnet.polypore.xyz:26656,"
+SYNC_RPC_1=http://consumer-1-state-sync-01.rs-testnet.polypore.xyz:26657
+SYNC_RPC_2=http://consumer-1-state-sync-02.rs-testnet.polypore.xyz:26657
+SYNC_RPC_SERVERS="$SYNC_RPC_1,$SYNC_RPC_2"
+
+# The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
+# GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/consumer-1/consumer-1-genesis.json
+
+# Install wget and jq
+sudo apt-get install curl jq wget -y
+
+# Install go 1.19.4
+echo "Installing go..."
+rm go*linux-amd64.tar.gz
+wget https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+
+# Install interchain-security-cd binary
+echo "Installing build-essential..."
+sudo apt install build-essential -y
+echo "Installing interchain-security-cd..."
+cd $HOME
+mkdir -p $HOME/go/bin
+rm -rf interchain-security
+git clone https://github.com/cosmos/interchain-security.git
+cd interchain-security
+git checkout v1.0.0-rc3
+make install
+export PATH=$PATH:$HOME/go/bin
+
+# Initialize home directory
+echo "Initializing $NODE_HOME..."
+rm -rf $NODE_HOME
+$CHAIN_BINARY config chain-id $CHAIN_ID --home $NODE_HOME
+$CHAIN_BINARY config keyring-backend test --home $NODE_HOME
+$CHAIN_BINARY config broadcast-mode block --home $NODE_HOME
+$CHAIN_BINARY init $NODE_MONIKER --chain-id $CHAIN_ID --home $NODE_HOME
+sed -i -e "/seeds =/ s^= .*^= \"$SEEDS\"^" $NODE_HOME/config/config.toml
+
+# Replace keys
+echo "Replacing keys..."
+cp $PRIV_VALIDATOR_KEY_FILE $NODE_HOME/config/priv_validator_key.json
+cp $NODE_KEY_FILE $NODE_HOME/config/node_key.json
+
+# Replace genesis file: only after the spawn time is reached
+# echo "Replacing genesis file..."
+# wget $GENESIS_URL -O genesis.json
+# mv genesis.json $NODE_HOME/config/genesis.json
+
+if $STATE_SYNC ; then
+    echo "Configuring state sync..."
+    CURRENT_BLOCK=$(curl -s $SYNC_RPC_1/block | jq -r '.result.block.header.height')
+    TRUST_HEIGHT=$[$CURRENT_BLOCK-1000]
+    TRUST_BLOCK=$(curl -s $SYNC_RPC_1/block\?height\=$TRUST_HEIGHT)
+    TRUST_HASH=$(echo $TRUST_BLOCK | jq -r '.result.block_id.hash')
+    sed -i -e '/enable =/ s/= .*/= true/' $NODE_HOME/config/config.toml
+    sed -i -e "/trust_height =/ s/= .*/= $TRUST_HEIGHT/" $NODE_HOME/config/config.toml
+    sed -i -e "/trust_hash =/ s/= .*/= \"$TRUST_HASH\"/" $NODE_HOME/config/config.toml
+    sed -i -e "/rpc_servers =/ s^= .*^= \"$SYNC_RPC_SERVERS\"^" $NODE_HOME/config/config.toml
+else
+    echo "Skipping state sync..."
+fi
+
+echo "Creating $SERVICE_NAME.service..."
+sudo rm /etc/systemd/system/$SERVICE_NAME.service
+sudo touch /etc/systemd/system/$SERVICE_NAME.service
+
+echo "[Unit]"                               | sudo tee /etc/systemd/system/$SERVICE_NAME.service
+echo "Description=consumer-1 service"       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "User=$USER"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "ExecStart=$HOME/go/bin/$CHAIN_BINARY start --x-crisis-skip-assert-invariants --home $NODE_HOME" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Restart=always"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "RestartSec=3"                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "[Install]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "WantedBy=multi-user.target"           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+
+# Start service
+sudo systemctl daemon-reload
+
+# Enable and start the service after the genesis that includes the CCV state is in place
+# sudo systemctl enable $SERVICE_NAME.service
+# sudo systemctl start $SERVICE_NAME.service
+# sudo systemctl restart systemd-journald
+
+# Add go and gaiad to the path
+echo "Setting up paths for go and interchain-security-cd bin..."
+echo "export PATH=$PATH:/usr/local/go/bin" >> .profile
+
+echo "***********************"
+echo "To see the service log enter:"
+echo "journalctl -fu $SERVICE_NAME.service"
+echo "***********************"

--- a/replicated-security/consumer-1/proposal-consumer-1.json
+++ b/replicated-security/consumer-1/proposal-consumer-1.json
@@ -1,0 +1,19 @@
+{
+    "title": "consumer-1 Chain",
+    "description": "# Launching the consumer-1 Chain\r\n\r\nThis is the proposal to create the first persistent consumer chain, \"consumer-1\".\r\n\r\nPlease visit the [cosmos/testnets](https://github.com/cosmos/testnets/tree/master/replicated-security) repo for additional details.",
+    "chain_id": "consumer-1",
+    "initial_height": {
+        "revision_height": 1,
+        "revision_number": 1
+    },
+    "genesis_hash": "d86d756e10118e66e6805e9cc476949da2e750098fcc7634fd0cc77f57a0b2b0",
+    "binary_hash": "376cdbd3a222a3d5c730c9637454cd4dd925e2f9e2e0d0f3702fc922928583f1",
+    "spawn_time": "2023-01-26T15:00:00.000000Z",
+    "blocks_per_distribution_transmission": 1000,
+    "consumer_redistribution_fraction": "0.75",
+    "historical_entries": 10000,
+    "transfer_timeout_period": 1800000000000,
+    "ccv_timeout_period": 259200000000000,
+    "unbonding_period": 86400000000000,
+    "deposit": "10000000uatom"
+}

--- a/replicated-security/timeout-1/README.md
+++ b/replicated-security/timeout-1/README.md
@@ -1,8 +1,9 @@
 
 # `timeout-1` Chain Details
 
+> Status: **STOPPED | reached `init_timeout_period`**
+
 The timeout-1 chain will be launched with the purpose of testing the provider chain `init_timeout_period` timeout. This chain will never start.
 
 - **Chain-ID**: `timeout-1`
 - **Launch date**: 2023-01-23
-

--- a/replicated-security/timeout-2/README.md
+++ b/replicated-security/timeout-2/README.md
@@ -1,6 +1,8 @@
 
 # `timeout-2` Chain Details
 
+> Status: **STARTED | waiting for `vsc_timeout_period`**
+
 The timeout-2 chain will be launched with the purpose of testing the provider chain `vsc_timeout_period` timeout. The relayer used to first establish the connection between `timeout-2` and `provider-1` will be stopped shortly afterwards in order to trigger the timeout.
 
 - **Chain-ID**: `timeout-2`

--- a/replicated-security/timeout-3/README.md
+++ b/replicated-security/timeout-3/README.md
@@ -1,6 +1,8 @@
 
 # `timeout-3` Chain Details
 
+> Status: **STARTED | waiting for `ccv_timeout_period`**
+
 The timeout-3 chain will be launched with the purpose of testing the provider chain `ccv_timeout_period` timeout. The relayer used to first establish the connection between `timeout-3` and `provider-1` will be stopped shortly afterwards. The relayer will then be started again after the `ccv_timeout_period` has elapsed but before the `vsc_timeout_period` is reached.
 
 - **Chain-ID**: `timeout-3`


### PR DESCRIPTION
The proposal to create the consumer-1 chain has passed.
Added the following for `consumer-1`:
- Spawn time
- Genesis file without CCV state
- Reference binary file
- Scripts to setup a node with and without Cosmovisor

Updated the schedule and RS readme to show that timeout-1 has now stopped.