### PR TITLE
Update RS testnet schedule

### DIFF
--- a/replicated-security/README.md
+++ b/replicated-security/README.md
@@ -14,16 +14,17 @@ This testnet includes the following:
 ### Live Chains
 
 * Provider: [`provider-1`](/replicated-security/provider-1/README.md)
-* Consumer: [`timeout-2`](/replicated-security/timeout-2/README.md) (Waiting to timeout on `vsc_timeout_period`)
-* Consumer: [`timeout-3`](/replicated-security/timeout-3/README.md) (Waiting to timeout on `ccv_timeout_period`)
-* Consumer: [`consumer-1`](/replicated-security/consumer-1/README.md)
 
 ### Stopped Chains
 
-* Consumer: [`timeout-1`](/replicated-security/timeout-1/README.md) (Timed out on provider `init_timeout_period`)
+* Consumer: [`timeout-1`](/replicated-security/timeout-1/README.md)
+* Consumer: [`timeout-2`](/replicated-security/timeout-2/README.md)
+* Consumer: [`timeout-3`](/replicated-security/timeout-3/README.md)
+* Consumer: [`consumer-1`](/replicated-security/consumer-1/README.md)
 
 ## Upcoming Events
 
-* 2023-01-30: `slasher-1` chain launch
+* `provider-1` chain binary update
+* `slasher-1` chain launch
 
 See the [RS testnet schedule](SCHEDULE.md) for consumer chain launches and other planned events.

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -1,17 +1,17 @@
 ## Replicated Security Testnet Schedule
 
-| Date            | Type   | Description                                                               |
-|-----------------|--------|---------------------------------------------------------------------------|
-| January 30 2023 | Test   | Consumer chain `slasher-1` is stopped                                     |
-| January 30 2023 | Test   | Consumer chain `slasher-1` is created                                     |
-| January 26 2023 | Test   | Consumer chain `timeout-2` reaches `vsc_timeout_period` timeout and stops |
-| January 26 2023 | Test   | Consumer chain `timeout-3` stops |
-| January 26 2023 | Test   | Relayer for `timeout-3` is started again                                  |
-| January 26 2023 | Launch | Consumer chain `consumer-1` is created and relayer started                |
-| January 25 2023 | Test   | ✅ Consumer chain `timeout-3` reaches `ccv_timeout_period` |
-| January 24 2023 | Test   | ✅ Consumer chain `timeout-1` reaches `init_timeout_period` and stops       |
-| January 23 2023 | Test   | ✅ Relayer for `timeout-3` is stopped                                      |
-| January 23 2023 | Test   | ✅ Relayer for `timeout-2` is stopped                                      |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-3` is created and relayer started               |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-2` is created and relayer started               |
-| January 23 2023 | Launch | ✅ Consumer chain `timeout-1` is created                                   |
+| Date                    | Type    | Description                                                                           |
+|-------------------------|---------|---------------------------------------------------------------------------------------|
+| Week of January 30 2023 | Test    | Consumer chain `slasher-1` is created and relayer started                             |
+| Week of January 30 2023 | Upgrade | Upgrade `provider-1` binary                                                           |
+| January 27 2023         | Test    | ✅ Consumer chains `timeout-1`, `timeout-2`, `timeout-3`, and `consumer-1` are stopped |
+| January 27 2023         | Test    | ✅ Consumer chain `consumer-1` IBC client expires                                      |
+| January 26 2023         | Launch  | ✅ Consumer chain `consumer-1` is created                                              |
+| January 24 2023         | Test    | ✅ Consumer chain `timeout-3` IBC client expires                                       |
+| January 24 2023         | Test    | ✅ Consumer chain `timeout-2` IBC client expires                                       |
+| January 24 2023         | Test    | ✅ Consumer chain `timeout-1` IBC client expires                                       |
+| January 23 2023         | Test    | ✅ Relayer for `timeout-3` is stopped                                                  |
+| January 23 2023         | Test    | ✅ Relayer for `timeout-2` is stopped                                                  |
+| January 23 2023         | Launch  | ✅ Consumer chain `timeout-3` is created and relayer started                           |
+| January 23 2023         | Launch  | ✅ Consumer chain `timeout-2` is created and relayer started                           |
+| January 23 2023         | Launch  | ✅ Consumer chain `timeout-1` is created                                               |

--- a/replicated-security/consumer-1/README.md
+++ b/replicated-security/consumer-1/README.md
@@ -1,7 +1,7 @@
 
 # `consumer-1` Chain Details
 
-> Status: **STARTED**
+> Status: **STOPPED**
 
 The `consumer-1` chain will be launched as a persistent dummy chain to test basic Interchain Security functionality.
 

--- a/replicated-security/timeout-1/README.md
+++ b/replicated-security/timeout-1/README.md
@@ -1,7 +1,7 @@
 
 # `timeout-1` Chain Details
 
-> Status: **STOPPED | reached `init_timeout_period`**
+> Status: **STOPPED | IBC client expired**
 
 The timeout-1 chain will be launched with the purpose of testing the provider chain `init_timeout_period` timeout. This chain will never start.
 

--- a/replicated-security/timeout-2/README.md
+++ b/replicated-security/timeout-2/README.md
@@ -1,7 +1,7 @@
 
 # `timeout-2` Chain Details
 
-> Status: **STARTED | waiting for `vsc_timeout_period`**
+> Status: **STOPPED | IBC client expired**
 
 The timeout-2 chain will be launched with the purpose of testing the provider chain `vsc_timeout_period` timeout. The relayer used to first establish the connection between `timeout-2` and `provider-1` will be stopped shortly afterwards in order to trigger the timeout.
 

--- a/replicated-security/timeout-3/README.md
+++ b/replicated-security/timeout-3/README.md
@@ -1,7 +1,7 @@
 
 # `timeout-3` Chain Details
 
-> Status: **STARTED | waiting for `ccv_timeout_period`**
+> Status: **STOPPED | IBC client expired**
 
 The timeout-3 chain will be launched with the purpose of testing the provider chain `ccv_timeout_period` timeout. The relayer used to first establish the connection between `timeout-3` and `provider-1` will be stopped shortly afterwards. The relayer will then be started again after the `ccv_timeout_period` has elapsed but before the `vsc_timeout_period` is reached.
 


### PR DESCRIPTION
- Set all consumer chains launched in week 1 to "stopped"
- Add upgrade binary event
- Remove date from slasher chain launch