### PR TITLE
Update Cosmos Hub public testnet to v8.0.0

### DIFF
--- a/devnet/README.md
+++ b/devnet/README.md
@@ -12,7 +12,7 @@ Integrators such as exchanges and wallets who want to test against Rho endpoints
 
 * **Chain ID**: `rho-chain-1`
 * **Launch date:** 2023-01-17
-* **Gaia version:** `v8.0.0-rc5`
+* **Gaia version:** `v8.0.0`
 * **Genesis file:** [rho-chain-1-genesis.json.gz](rho-chain-1-genesis.json.gz)
 * **Persistent peer:** `42c0aa9a5e922ae446fa8537f076854a6c2c5053@sentry.chain-1.rho-devnet.polypore.xyz:26656`
 
@@ -38,7 +38,7 @@ Integrators such as exchanges and wallets who want to test against Rho endpoints
 
 - **Chain ID**: `rho-chain-2`
 - **Launch date:** 2023-01-17
-- **Gaia version:** `v8.0.0-rc5`
+- **Gaia version:** `v8.0.0`
 - **Genesis file:** [rho-chain-2-genesis.json.gz](rho-chain-2-genesis.json.gz)
 * **Persistent peer:** `c45efb232d01df3b2399ef9b4b801fd41f6a89fc@sentry.chain-2.rho-devnet.polypore.xyz:26656`
 

--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v8.0.0-rc5` (upgraded to v8 at height `14175595`)
+- **Current Gaia Version:** `v8.0.0` (upgraded to v8 at height `14175595`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
@@ -110,7 +110,7 @@ Run either one of the scripts provided in this repo to join the provider chain:
 
 If you want to use Cosmovisor's **auto-download** feature, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=true`
 
-If you are **manually preparing your binary**, please set the environement variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v8.0.0-rc5 binary to the v8-Rho upgrade directory in your cosmovisor directory (`upgrades/v8-rho/bin/gaiad`). **If you are using Cosmovisor `v1.0.0`, the version name is not lowercased (use `upgrades/v8-Rho/bin/gaiad` instead)**.
+If you are **manually preparing your binary**, please set the environement variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v8.0.0 binary to the v8-Rho upgrade directory in your cosmovisor directory (`upgrades/v8-rho/bin/gaiad`). **If you are using Cosmovisor `v1.0.0`, the version name is not lowercased (use `upgrades/v8-Rho/bin/gaiad` instead)**.
 
 ```
 .

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v8.0.0/gaiad-v8.0.0-linux-amd64'
 STATE_SYNC=true
 # ***
 
@@ -42,7 +42,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v8.0.0-rc5
+# git checkout v8.0.0
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v8.0.0/gaiad-v8.0.0-linux-amd64'
 STATE_SYNC=true
 # ***
 
@@ -42,7 +42,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v8.0.0-rc5
+# git checkout v8.0.0
 # make install
 
 export PATH=$PATH:$HOME/go/bin


### PR DESCRIPTION
Updated README and bash scripts with `v8.0.0`.