### PR TITLE
Upgrade public testnets to v9.0.0-rc6

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v9.0.0-rc3` (upgraded to v9 at height `14476207`)
+- **Current Gaia Version:** `v9.0.0-rc6` (upgraded to v9 at height `14476207`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc6/gaiad-v9.0.0-rc6-linux-amd64'
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
 # ***
@@ -43,7 +43,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.0-rc3
+# git checkout v9.0.0-rc6
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc6/gaiad-v9.0.0-rc6-linux-amd64'
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
 # ***
@@ -43,7 +43,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.0-rc3
+# git checkout v9.0.0-rc6
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -5,10 +5,11 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 * **Chain-ID**: `provider`
 * **denom**: `uatom`
-* **Launch date**: 2023-02-02
-* **Launch Gaia Version:** [`v9.0.0-rc2`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc2)
+* **Current Gaia Version**: [`v9.0.0-rc6`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc6)
 * **Genesis File:**  [provider-genesis.json](provider-genesis.json), verify with `shasum -a 256 provider-genesis.json`
 * **Genesis sha256sum**: `91870bfb8671f5d60c303f9da8e44b620a5403f913359cc6b212150bfc3e631d`
+* Launch Date: 2023-02-02
+* Launch Gaia Version: [`v9.0.0-rc2`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc2)
 
 ## Endpoints
 

--- a/replicated-security/provider/join-rs-provider-cv.sh
+++ b/replicated-security/provider/join-rs-provider-cv.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=cv-provider
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc2/gaiad-v9.0.0-rc2-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc6/gaiad-v9.0.0-rc6-linux-amd64'
 STATE_SYNC=true
 # ***
 
@@ -54,7 +54,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.0-rc2
+# git checkout v9.0.0-rc6
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/replicated-security/provider/join-rs-provider.sh
+++ b/replicated-security/provider/join-rs-provider.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=provider
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc2/gaiad-v9.0.0-rc2-linux-amd64'
+CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.0-rc6/gaiad-v9.0.0-rc6-linux-amd64'
 STATE_SYNC=true
 # ***
 
@@ -54,7 +54,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.0-rc2
+# git checkout v9.0.0-rc6
 # make install
 
 export PATH=$PATH:$HOME/go/bin


### PR DESCRIPTION
The following chains have been updated to Gaia `v9.0.0-rc6`:
- Cosmos Hub Public Testnet (`theta-testnet-001`)
- Replicated Security Testnet `provider` chain