### PR TITLE
jsfiddle link to add provider chain to Keplr

### DIFF
--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -35,6 +35,10 @@ The following state sync nodes serve snapshots every 1000 blocks:
 1. `provider-state-sync-01.rs-testnet.polypore.xyz`
 2. `provider-state-sync-02.rs-testnet.polypore.xyz`
 
+## Add to Keplr
+
+Use this [jsfiddle](https://jsfiddle.net/uw4ar8qt/2/).
+
 ## Block Explorer
 
 * https://explorer.rs-testnet.polypore.xyz


### PR DESCRIPTION
Add link to [this jsfiddle](https://jsfiddle.net/uw4ar8qt/2/) to add "RS testnet - provider" to Keplr.