### PR TITLE
There's a mistake for checksum of binary for 0.3.1

### DIFF
--- a/replicated-security/baryon-1/v0.3.0_upgrade.md
+++ b/replicated-security/baryon-1/v0.3.0_upgrade.md
@@ -65,7 +65,7 @@ That problem was that `UpgradeHandler` was not implemented and migration of some
 
 ```shell
 $ shasum -a 256 neutrond
-56ac5b3ed9746a50f6acdb401252073d5cf5f01d48b2395cd727ffde58e9c02d neutrond
+0a92982d15cfcea18d0b5adf510d78435b2c678c9947e4a69912f6d7a25a8ed2 neutrond
 ```
 
 ## Copy the new neutron (v0.3.1) binary to cosmovisor upgrades directory


### PR DESCRIPTION
The correct one is: 0a92982d15cfcea18d0b5adf510d78435b2c678c9947e4a69912f6d7a25a8ed2

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v If adding a new genesis file, make sure you also 
v update the `latest` directory. This is so the SDK repo
v can always just link to `latest` in the docs :)
v    
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Duplicated new genesis file in `latest` directory
