### PR TITLE
Upgraded testnets to Gaia v10

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v9.0.3` (upgraded to v9 at height `14476207`)
+- **Current Gaia Version:** `v10.0.0-rc0` (upgraded to v10 at height `16117530`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
@@ -110,22 +110,7 @@ Run either one of the scripts provided in this repo to join the provider chain:
 
 If you want to use Cosmovisor's **auto-download** feature, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=true`
 
-If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v9.0.0-rc3 binary to the v9-Lambda upgrade directory in your cosmovisor directory (`upgrades/v9-lambda/bin/gaiad`). 
-
-> **Warning**  <span style="color:red">**Please Read Before Proceeding**</span><br>
-> **Using Cosmovisor 1.2.0 and higher requires a lowercase naming convention for the upgrade version directory. For Cosmovisor 1.1.0 and earlier, the upgrade version is not lowercased.**       
-> 
-> **For Example:** <br>
-> **Cosmovisor <= `v1.1.0`: `/upgrades/v9-Lambda/bin/gaiad`**<br>
-> **Cosmovisor >= `v1.2.0`: `/upgrades/v9-lambda/bin/gaiad`**<br>
-
-| Cosmovisor Version | Upgrade Folder Name |
-|:------------------:|---------------------|
-|      `v1.3.0`      | v9-lambda           |
-|      `v1.2.0`      | v9-lambda           |
-|      `v1.1.0`      | v9-Lambda           |
-|      `v1.0.0`      | v9-Lambda           |
-
+If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v10.0.0-rc0 binary to the v10 upgrade directory in your cosmovisor directory (`upgrades/v10/bin/gaiad`). 
 
 ```
 .
@@ -134,7 +119,7 @@ If you are **manually preparing your binary**, please set the environment variab
 │   └── bin
 │       └── gaiad
 └── upgrades
-    └── v9-lambda
+    └── v10
         ├── bin
         │   └── gaiad
         └── upgrade-info.json

--- a/public/UPGRADES.md
+++ b/public/UPGRADES.md
@@ -6,7 +6,7 @@
 
 | Date        | Testnet plan                                                                                                                       |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| May 24 2023 | ~14:00 UTC: v10 upgrade ([Gaia v10.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v10.0.0-rc0)) is live on the testnet |
+| May 24 2023 | ✅ [Gaia v10.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v10.0.0-rc0) is live on the testnet |
 | May 24 2023 | ✅ Submit and pass v10 software upgrade [proposal](https://explorer.theta-testnet.polypore.xyz/proposals/167)                                                                          |
 
 * **Version before upgrade**: `v9.0.3`
@@ -15,7 +15,8 @@
 ### Upgrade details
 
 * Upgrade height: `16117530` 
-* Upgrade time: `~14:00 UTC`
+* Upgrade time: `2023-05-24 13:59:49 UTC`
+  * The upgrade took three minutes, and block `16117532` was indexed at `14:03:19 UTC`
 
 ## v9-Lambda
 

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,8 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.3/gaiad-v9.0.3-linux-amd64'
+GAIA_VERSION=v10.0.0
+CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
 # ***
@@ -21,11 +22,11 @@ SYNC_RPC="https://rpc.state-sync-01.theta-testnet.polypore.xyz:443,https://rpc.s
 # Install wget and jq
 sudo apt-get install curl jq wget -y
 
-# Install go 1.18.5
+# Install go 1.20
 echo "Installing go..."
 rm go*linux-amd64.tar.gz
-wget https://go.dev/dl/go1.18.5.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.5.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Install Gaia binary
@@ -43,7 +44,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.3
+# git checkout $GAIA_VERSION
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,8 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.3/gaiad-v9.0.3-linux-amd64'
+GAIA_VERSION=v10.0.0
+CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
 # ***
@@ -21,11 +22,11 @@ SYNC_RPC="https://rpc.state-sync-01.theta-testnet.polypore.xyz:443,https://rpc.s
 # Install wget and jq
 sudo apt-get install curl jq wget -y
 
-# Install go 1.18.5
+# Install go 1.20
 echo "Installing go..."
 rm go*linux-amd64.tar.gz
-wget https://go.dev/dl/go1.18.5.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.5.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Install Gaia binary
@@ -43,7 +44,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.3
+# git checkout $GAIA_VERSION
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -1,39 +1,39 @@
 ## Replicated Security Testnet Schedule
 
-| Date            | Type              | Description                                                                            |
-| --------------- | ----------------- | -------------------------------------------------------------------------------------- |
-| June 14 2023    | Consumer upgrade  | Consumer chain `pion-1` to be upgraded (version TBC)                                   |
-| ~May     2023   | Consumer addition | Consumer chain `stride-1` transitions from sovereign to RS-secured                     |
-| May 31 2023     | Consumer addition | Consumer chain `duality-rehearsal-1` is created and relayer started                    |
-| May 24 2023     | Major upgrade     | Provider chain upgraded to v10.0.0-rc0 via governance proposal                         |
-| May 17 2023     | Minor upgrade     | ✅ Provider chain upgraded to v9.1.0                                                   |
-| May 3    2023   | Consumer upgrade  | ✅ Consumer chain `pion-1` upgraded to v1.0.0-rc1                                      |
-| April 25 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.3                                                   |
-| April 20 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.3-rc0                                               |
-| April 19 2023   | Consumer removal  | ✅ Consumer chain `neutron-rehearsal-fix-1` is removed via governance proposal         |
-| April 18 2023   | Consumer removal  | ✅ Consumer chain `baryon-1` is removed via governance proposal                        |
-| April 18 2023   | Consumer addition | ✅ Consumer chain `pion-1` is created and relayer started                              |
-| April 14 2023   | Consumer removal  | ✅ Consumer chain `neutron-rehearsal-1` is removed via governance proposal             |
-| April 13 2023   | Consumer addition | ✅ Consumer chain `neutron-rehearsal-fix-1` is created and relayer started             |
-| April 11 2023   | Consumer addition | ✅ Consumer chain `neutron-rehearsal-1` is created and relayer started                 |
-| April 4  2023   | Consumer upgrade  | ✅ Consumer chain `baryon-1` is upgraded via consumer chain governance                 |
-| March 29 2023   | Consumer removal  | ✅ Consumer chain `removeme` is removed via governance proposal                        |
-| March 28 2023   | Consumer addition | ✅ Consumer chain `removeme` is created and relayer started                            |
-| March 27 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.2-rc0                                               |
-| March 23 2023   | Consumer removal  | ✅ Consumer chain `noble-1` is removed via governance proposal                         |
-| February 9 2023 | Consumer addition | ✅ Consumer chain `noble-1` is created and relayer started                             |
-| February 7 2023 | Consumer addition | ✅ Consumer chain `baryon-1` is created and relayer started                            |
-| February 6 2023 | Test              | ✅ Consumer chain `slasher` is stopped via governance proposal                         |
-| February 3 2023 | Test              | ✅ Consumer chain `slasher` is created and relayer started                             |
-| February 2 2023 | Launch            | ✅ `provider-1` chain is re-started as `provider` with Gaia `v9.0.0-rc2`               |
-| January 27 2023 | Test              | ✅ Consumer chains `timeout-1`, `timeout-2`, `timeout-3`, and `consumer-1` are stopped |
-| January 27 2023 | Test              | ✅ Consumer chain `consumer-1` IBC client expires                                      |
-| January 26 2023 | Consumer addition | ✅ Consumer chain `consumer-1` is created                                              |
-| January 24 2023 | Test              | ✅ Consumer chain `timeout-3` IBC client expires                                       |
-| January 24 2023 | Test              | ✅ Consumer chain `timeout-2` IBC client expires                                       |
-| January 24 2023 | Test              | ✅ Consumer chain `timeout-1` IBC client expires                                       |
-| January 23 2023 | Test              | ✅ Relayer for `timeout-3` is stopped                                                  |
-| January 23 2023 | Test              | ✅ Relayer for `timeout-2` is stopped                                                  |
-| January 23 2023 | Launch            | ✅ Consumer chain `timeout-3` is created and relayer started                           |
-| January 23 2023 | Launch            | ✅ Consumer chain `timeout-2` is created and relayer started                           |
-| January 23 2023 | Launch            | ✅ Consumer chain `timeout-1` is created                                               |
+| Date            | Type              | Description                                                                                                                  |
+| --------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| June 14 2023    | Consumer upgrade  | Consumer chain `pion-1` to be upgraded (version TBC)                                                                         |
+| ~May     2023   | Consumer addition | Consumer chain `stride-1` transitions from sovereign to RS-secured                                                           |
+| May 31 2023     | Consumer addition | Consumer chain `duality-rehearsal-1` is created and relayer started                                                          |
+| May 24 2023     | Major upgrade     | ✅ Provider chain upgraded to v10.0.0-rc0 via governance [proposal](https://explorer.rs-testnet.polypore.xyz/provider/gov/30) |
+| May 17 2023     | Minor upgrade     | ✅ Provider chain upgraded to v9.1.0                                                                                          |
+| May 3    2023   | Consumer upgrade  | ✅ Consumer chain `pion-1` upgraded to v1.0.0-rc1                                                                             |
+| April 25 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.3                                                                                          |
+| April 20 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.3-rc0                                                                                      |
+| April 19 2023   | Consumer removal  | ✅ Consumer chain `neutron-rehearsal-fix-1` is removed via governance proposal                                                |
+| April 18 2023   | Consumer removal  | ✅ Consumer chain `baryon-1` is removed via governance proposal                                                               |
+| April 18 2023   | Consumer addition | ✅ Consumer chain `pion-1` is created and relayer started                                                                     |
+| April 14 2023   | Consumer removal  | ✅ Consumer chain `neutron-rehearsal-1` is removed via governance proposal                                                    |
+| April 13 2023   | Consumer addition | ✅ Consumer chain `neutron-rehearsal-fix-1` is created and relayer started                                                    |
+| April 11 2023   | Consumer addition | ✅ Consumer chain `neutron-rehearsal-1` is created and relayer started                                                        |
+| April 4  2023   | Consumer upgrade  | ✅ Consumer chain `baryon-1` is upgraded via consumer chain governance                                                        |
+| March 29 2023   | Consumer removal  | ✅ Consumer chain `removeme` is removed via governance proposal                                                               |
+| March 28 2023   | Consumer addition | ✅ Consumer chain `removeme` is created and relayer started                                                                   |
+| March 27 2023   | Patch upgrade     | ✅ Provider chain upgraded to v9.0.2-rc0                                                                                      |
+| March 23 2023   | Consumer removal  | ✅ Consumer chain `noble-1` is removed via governance proposal                                                                |
+| February 9 2023 | Consumer addition | ✅ Consumer chain `noble-1` is created and relayer started                                                                    |
+| February 7 2023 | Consumer addition | ✅ Consumer chain `baryon-1` is created and relayer started                                                                   |
+| February 6 2023 | Test              | ✅ Consumer chain `slasher` is stopped via governance proposal                                                                |
+| February 3 2023 | Test              | ✅ Consumer chain `slasher` is created and relayer started                                                                    |
+| February 2 2023 | Launch            | ✅ `provider-1` chain is re-started as `provider` with Gaia `v9.0.0-rc2`                                                      |
+| January 27 2023 | Test              | ✅ Consumer chains `timeout-1`, `timeout-2`, `timeout-3`, and `consumer-1` are stopped                                        |
+| January 27 2023 | Test              | ✅ Consumer chain `consumer-1` IBC client expires                                                                             |
+| January 26 2023 | Consumer addition | ✅ Consumer chain `consumer-1` is created                                                                                     |
+| January 24 2023 | Test              | ✅ Consumer chain `timeout-3` IBC client expires                                                                              |
+| January 24 2023 | Test              | ✅ Consumer chain `timeout-2` IBC client expires                                                                              |
+| January 24 2023 | Test              | ✅ Consumer chain `timeout-1` IBC client expires                                                                              |
+| January 23 2023 | Test              | ✅ Relayer for `timeout-3` is stopped                                                                                         |
+| January 23 2023 | Test              | ✅ Relayer for `timeout-2` is stopped                                                                                         |
+| January 23 2023 | Launch            | ✅ Consumer chain `timeout-3` is created and relayer started                                                                  |
+| January 23 2023 | Launch            | ✅ Consumer chain `timeout-2` is created and relayer started                                                                  |
+| January 23 2023 | Launch            | ✅ Consumer chain `timeout-1` is created                                                                                      |

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -5,7 +5,7 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 * **Chain-ID**: `provider`
 * **denom**: `uatom`
-* **Current Gaia Version**: [`v9.1.0`](https://github.com/cosmos/gaia/releases/tag/v9.1.0)
+* **Current Gaia Version**: [`v10.0.0-rc0`](https://github.com/cosmos/gaia/releases/tag/v10.0.0-rc0)
 * **Genesis File:**  [provider-genesis.json](provider-genesis.json), verify with `shasum -a 256 provider-genesis.json`
 * **Genesis sha256sum**: `91870bfb8671f5d60c303f9da8e44b620a5403f913359cc6b212150bfc3e631d`
 * Launch Date: 2023-02-02

--- a/replicated-security/provider/join-rs-provider-cv.sh
+++ b/replicated-security/provider/join-rs-provider-cv.sh
@@ -16,7 +16,8 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=cv-provider
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.3/gaiad-v9.0.3-linux-amd64'
+GAIA_VERSION=v10.0.0
+CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***
 
@@ -31,11 +32,11 @@ SYNC_RPC_SERVERS="$SYNC_RPC_1,$SYNC_RPC_2"
 # Install wget and jq
 sudo apt-get install curl jq wget -y
 
-# Install go 1.18.5
+# Install go 1.20
 echo "Installing go..."
 rm go*linux-amd64.tar.gz
-wget https://go.dev/dl/go1.18.5.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.5.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Install Gaia binary
@@ -54,7 +55,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.3
+# git checkout $GAIA_VERSION
 # make install
 
 export PATH=$PATH:$HOME/go/bin

--- a/replicated-security/provider/join-rs-provider.sh
+++ b/replicated-security/provider/join-rs-provider.sh
@@ -16,7 +16,8 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=provider
-CHAIN_BINARY_URL='https://github.com/cosmos/gaia/releases/download/v9.0.3/gaiad-v9.0.3-linux-amd64'
+GAIA_VERSION=v10.0.0
+CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***
 
@@ -31,11 +32,11 @@ SYNC_RPC_SERVERS="$SYNC_RPC_1,$SYNC_RPC_2"
 # Install wget and jq
 sudo apt-get install curl jq wget -y
 
-# Install go 1.18.5
+# Install go 1.20
 echo "Installing go..."
 rm go*linux-amd64.tar.gz
-wget https://go.dev/dl/go1.18.5.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.5.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Install Gaia binary
@@ -54,7 +55,7 @@ chmod +x $HOME/go/bin/$CHAIN_BINARY
 # rm -rf gaia
 # git clone https://github.com/cosmos/gaia.git
 # cd gaia
-# git checkout v9.0.3
+# git checkout $GAIA_VERSION
 # make install
 
 export PATH=$PATH:$HOME/go/bin


### PR DESCRIPTION
* Updated READMEs, upgrade schedules, and scripts to join the `theta-testnet-001` and `provider` chains.
* Closes #430 and #431 