### PR TITLE
Duality testnet-1 seed node info update

### DIFF
--- a/replicated-security/duality-testnet-1/README.md
+++ b/replicated-security/duality-testnet-1/README.md
@@ -106,8 +106,8 @@ after installation please check installed version by running:
 You should see the following:
 
 ```
-name: Duality
+name: duality
 server_name: dualityd
-version: 0.3.0
-commit: 98fc9734cfe79bf56015d630219d4ed30b02ae72
+version: 0.3.4
+commit: 15cb02ba6b8c87723c7fd4bd4ce0c3bf660d6aff
 ```

--- a/replicated-security/duality-testnet-1/README.md
+++ b/replicated-security/duality-testnet-1/README.md
@@ -38,7 +38,7 @@ Endpoints are exposed as subdomains for the sentry and snapshot nodes (described
 
 Seed nodes:
 
-1. `2b92aec80bbac6f559a2444b3f14f54b12afcab1@p2p.testnet-1.duality.xyz:26656`
+1. `df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-1.duality.xyz:26656`
 
 ## IBC Data
 

--- a/replicated-security/duality-testnet-1/join-rs-duality-testnet-1-cv.sh
+++ b/replicated-security/duality-testnet-1/join-rs-duality-testnet-1-cv.sh
@@ -18,7 +18,7 @@ SERVICE_NAME=cv-duality
 
 CHAIN_BINARY='dualityd'
 CHAIN_ID=duality-testnet-1
-SEEDS="2b92aec80bbac6f559a2444b3f14f54b12afcab1@p2p.testnet-2.duality.xyz:26656"
+SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-2.duality.xyz:26656"
 
 # The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
 GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/duality-testnet-1/duality-testnet-1-genesis.json

--- a/replicated-security/duality-testnet-1/join-rs-duality-testnet-1-cv.sh
+++ b/replicated-security/duality-testnet-1/join-rs-duality-testnet-1-cv.sh
@@ -18,7 +18,7 @@ SERVICE_NAME=cv-duality
 
 CHAIN_BINARY='dualityd'
 CHAIN_ID=duality-testnet-1
-SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-2.duality.xyz:26656"
+SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-1.duality.xyz:26656"
 
 # The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
 GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/duality-testnet-1/duality-testnet-1-genesis.json

--- a/replicated-security/duality-testnet-1/join-rs-duality-testnet-1.sh
+++ b/replicated-security/duality-testnet-1/join-rs-duality-testnet-1.sh
@@ -18,7 +18,7 @@ SERVICE_NAME=duality
 
 CHAIN_BINARY='dualityd'
 CHAIN_ID=duality-testnet-1
-SEEDS="2b92aec80bbac6f559a2444b3f14f54b12afcab1@p2p.testnet-2.duality.xyz:26656"
+SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-2.duality.xyz:26656"
 
 # The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
 GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/duality-testnet-1/duality-testnet-1-genesis.json

--- a/replicated-security/duality-testnet-1/join-rs-duality-testnet-1.sh
+++ b/replicated-security/duality-testnet-1/join-rs-duality-testnet-1.sh
@@ -18,7 +18,7 @@ SERVICE_NAME=duality
 
 CHAIN_BINARY='dualityd'
 CHAIN_ID=duality-testnet-1
-SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-2.duality.xyz:26656"
+SEEDS="df5b21498dd5594a609e2e2af41434bbd9297ffd@p2p.testnet-1.duality.xyz:26656"
 
 # The genesis file that includes the CCV state will not be published until after the spawn time has been reached.
 GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/duality-testnet-1/duality-testnet-1-genesis.json


### PR DESCRIPTION
Update to add new seed node ID.

We tried to keep the same node ID through the setup, but it was my fault that I lost the key (I saved the wrong key) and now the seed node has a new node ID. sorry 🙏 

I've also added a commit to update the `dualityd version` info as I see its a little behind where the actual release was.
And an update to the p2p subdomain name in the scripts (which should be the same as other endpoints of the seednode).