### PR TITLE
Set Gaia v11 upgrade heights

### DIFF
--- a/public/UPGRADES.md
+++ b/public/UPGRADES.md
@@ -4,17 +4,17 @@
 
 ### Schedule
 
-| Date         | Testnet plan                                                                                       |
-| ------------ | -------------------------------------------------------------------------------------------------- |
-| July 26 2023 | [Gaia v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) is live on the testnet |
-| July 25 2023 | Submit and pass v11 software upgrade proposal                                                      |
+| Date         | Testnet plan                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------------ |
+| July 26 2023 | [Gaia v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) is live on the testnet           |
+| July 25 2023 | ✅ Submit and pass v11 software upgrade [proposal](https://explorer.theta-testnet.polypore.xyz/proposals/169) |
 
 * **Version before upgrade**: `v10.0.2`
 * **Version after upgrade**: `v11.0.0-rc0`
 
 ### Upgrade details
 
-* **Upgrade height: `TBD`**
+* **Upgrade height: `17107825`**
   * Target upgrade time: `2023-07-26 13:30:00 UTC`
 
 ## v10

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -11,8 +11,8 @@
 | August 2 2023      |                       |
 | July 26  2023      | Consumer upgrade      | Consumer chain `pion-1` to be upgraded to Neutron `v1.0.3`                                                                   |
 | July 26  2023      | Major upgrade         | Provider chain upgrades to Gaia `v11.0.0-rc0`                                                                                |
-| July 25  2023      | Major upgrade         | Proposal to upgrade provider chain to Gaia v11 passes                                                                        |
-| July 19  2023      | No testnet event      | Stride launches on mainnet                                                                                                   |
+| July 25  2023      | Major upgrade         | ✅ [Proposal](https://explorer.rs-testnet.polypore.xyz/provider/gov/45) to upgrade provider chain to Gaia v11 passes          |
+| July 19  2023      | No testnet event      | ✅ Stride launches on mainnet                                                                                                 |
 | July 12  2023      | Consumer addition     | ✅ Consumer chain `duality-testnet-1` is created and relayer started                                                          |
 | July 5  2023       | Consumer addition     | ✅ Stride testnet transitions to consumer chain `stride-ics-testnet-two-1`                                                    |
 | June 29 2023       | Consumer addition     | ✅ Consumer chain `pion-1` relaunched from stateful genesis                                                                   |

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -15,8 +15,9 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 The provider chain will upgrade to [v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) on **Wednesday, July 26 2023**.
 
-* **Block height: `TBD`**
+* **Block height: `2532935`**
   * Target upgrade time: `2023-07-26 14:00:00 UTC`
+* [Proposal #45](https://explorer.rs-testnet.polypore.xyz/provider/gov/45)
 * Golang version: 1.20
 
 ## Endpoints


### PR DESCRIPTION
Upgrading release testnet and provider chain of the RS testnet.