### PR TITLE
Testnets Upgraded to v11

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v10.0.2` (upgraded to v10 at height `16117530`)
+- **Current Gaia Version:** `v11.0.0-rc0` (upgraded to v10 at height `17107825`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
@@ -110,7 +110,7 @@ Run either one of the scripts provided in this repo to join the provider chain:
 
 If you want to use Cosmovisor's **auto-download** feature, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=true`
 
-If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v11.0.0-rc0 binary to the v11 upgrade directory in your cosmovisor directory (`upgrades/v10/bin/gaiad`). 
+If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v12.0.0-rc0 binary to the v12 upgrade directory in your cosmovisor directory (`upgrades/v12/bin/gaiad`). 
 
 ```
 .
@@ -119,7 +119,7 @@ If you are **manually preparing your binary**, please set the environment variab
 │   └── bin
 │       └── gaiad
 └── upgrades
-    └── v11
+    └── v12
         ├── bin
         │   └── gaiad
         └── upgrade-info.json

--- a/public/UPGRADES.md
+++ b/public/UPGRADES.md
@@ -6,7 +6,7 @@
 
 | Date         | Testnet plan                                                                                                 |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
-| July 26 2023 | [Gaia v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) is live on the testnet           |
+| July 26 2023 | ✅ [Gaia v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) is live on the testnet           |
 | July 25 2023 | ✅ Submit and pass v11 software upgrade [proposal](https://explorer.theta-testnet.polypore.xyz/proposals/169) |
 
 * **Version before upgrade**: `v10.0.2`
@@ -15,7 +15,8 @@
 ### Upgrade details
 
 * **Upgrade height: `17107825`**
-  * Target upgrade time: `2023-07-26 13:30:00 UTC`
+* Upgrade time: `2023-07-26 13:30:40 UTC`
+  * The upgrade took two minutes, and block `17107827` was indexed at `13:32:58 UTC`
 
 ## v10
 

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-GAIA_VERSION=v10.0.2
+GAIA_VERSION=v11.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-GAIA_VERSION=v10.0.2
+GAIA_VERSION=v11.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -9,8 +9,8 @@
 | August 16  2023    |                       |                                                                                                                              |
 | August 9  2023     | Consumer addition     | Consumer chain for Noble (name tbd) is created and relayer started                                                           |
 | August 2 2023      |                       |
-| July 26  2023      | Consumer upgrade      | Consumer chain `pion-1` to be upgraded to Neutron `v1.0.4`                                                                   |
-| July 26  2023      | Major upgrade         | Provider chain upgrades to Gaia `v11.0.0-rc0`                                                                                |
+| July 26  2023      | Consumer upgrade      | ✅ Consumer chain `pion-1` to be upgraded to Neutron `v1.0.4`                                                                   |
+| July 26  2023      | Major upgrade         | ✅ Provider chain upgrades to Gaia `v11.0.0-rc0`                                                                                |
 | July 25  2023      | Major upgrade         | ✅ [Proposal](https://explorer.rs-testnet.polypore.xyz/provider/gov/45) to upgrade provider chain to Gaia v11 passes          |
 | July 19  2023      | No testnet event      | ✅ Stride launches on mainnet                                                                                                 |
 | July 12  2023      | Consumer addition     | ✅ Consumer chain `duality-testnet-1` is created and relayer started                                                          |

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -5,20 +5,11 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 * **Chain-ID**: `provider`
 * **denom**: `uatom`
-* **Current Gaia Version**: [`v10.0.2`](https://github.com/cosmos/gaia/releases/tag/v10.0.2)
+* **Current Gaia Version**: [`v11.0.0-rc0`](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0), upgraded from v10 at block height `2532935`.
 * **Genesis File:**  [provider-genesis.json](provider-genesis.json), verify with `shasum -a 256 provider-genesis.json`
 * **Genesis sha256sum**: `91870bfb8671f5d60c303f9da8e44b620a5403f913359cc6b212150bfc3e631d`
 * Launch Date: 2023-02-02
 * Launch Gaia Version: [`v9.0.0-rc2`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc2)
-
-## v11 Upgrade
-
-The provider chain will upgrade to [v11.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v11.0.0-rc0) on **Wednesday, July 26 2023**.
-
-* **Block height: `2532935`**
-  * Target upgrade time: `2023-07-26 14:00:00 UTC`
-* [Proposal #45](https://explorer.rs-testnet.polypore.xyz/provider/gov/45)
-* Golang version: 1.20
 
 ## Endpoints
 
@@ -119,6 +110,10 @@ Run the script, and then follow the procedure below to upgrade to the latest ver
 * Replace the `v9.0.0-rc2` binary with the `v9.0.0-rc6` one in `~/go/bin`, or `~/.gaia/cosmovisor/current/bin` if you are using Cosmovisor.
 * Start the service.
 * When the node reaches height `228100`, stop the service.
-* Set `halt-height = 0` in `~/.gaia/config/app.toml`.
+* Set `halt-height = 1534600` in `~/.gaia/config/app.toml`.
 * Replace the `v9.0.0-rc6` binary with the `v9.0.1-rc0` one.
 * Start the service.
+* When the node reaches height `1534600`, stop the service.
+* Replace the `v9.0.0-rc6` binary with the `v9.1.0` one in `~/go/bin`, or `~/.gaia/cosmovisor/current/bin` if you are using Cosmovisor.
+* When the node reaches height `1634770`, it will attempt to upgrade to Gaia `v10`. You can use Cosmovisor's auto-download feature or install the `v10.0.0-rc0` release binary.
+* When the node reaches height `2532935`, it will attempt to upgrade to Gaia `v11`. You can use Cosmovisor's auto-download feature or install the `v11.0.0-rc0` release binary

--- a/replicated-security/provider/join-rs-provider-cv.sh
+++ b/replicated-security/provider/join-rs-provider-cv.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=cv-provider
-GAIA_VERSION=v10.0.2
+GAIA_VERSION=v11.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***

--- a/replicated-security/provider/join-rs-provider.sh
+++ b/replicated-security/provider/join-rs-provider.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=provider
-GAIA_VERSION=v10.0.2
+GAIA_VERSION=v11.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***


### PR DESCRIPTION
The release testnet and provider chain of RS testnet are now running Gaia `v11.0.0-rc0`.