### PR TITLE
V12 upgrade complete

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -3,7 +3,7 @@
 These instructions will help you simulate the `v12` upgrade on a single validator node testnet as follows:
 
 - Start with gaia version: `v11.0.0`
-- After the upgrade: Gaia release `v12.0.0-rc0`
+- After the upgrade: Gaia release `v12.0.0`
 
 We will use a modified genesis file during this upgrade. This modified genesis file is similar to the one we are running on the public testnet, and has been modified in part to replace an existing validator (Coinbase Custody) with a new validator account that we control. The account's mnemonic, validator key, and node key are provided in this repo.  
 For a full list of modifications to the genesis file, please [see below](#genesis-modifications).
@@ -236,7 +236,7 @@ wget -q https://go.dev/dl/go1.20.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
 
 cd $HOME/gaia
-git checkout v12.0.0-rc0
+git checkout v12.0.0
 git pull
 make install
 ```
@@ -257,7 +257,7 @@ gaiad tx gov submit-proposal software-upgrade v12 \
 --title "v12 Upgrade" \
 --deposit 100uatom \
 --upgrade-height TBD \
---upgrade-info '{"binaries":{"darwin/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-darwin-amd64?checksum=sha256:583512ae5615fab0c704ab35a7afbe7a57d0ea49aaf5aa98862f77bdb25bd4d5","darwin/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-darwin-arm64?checksum=sha256:51a499905fcb9b6db29d7be280e71fee256e8d7ca226304bae407202bce000c0","linux/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-linux-amd64?checksum=sha256:b7e1a3a0c5f1d528fa7a823900e47d2b91a7752f9264422f3883dc3394a20d90","linux/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-linux-arm64?checksum=sha256:d905a8cae5792ab7ed43fe897fcbd6b083d72be9106024f787e03529ee794d68","windows/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-windows-amd64.exe?checksum=sha256:242c047356dc882973e82e934d40cf04bd82d6ac698ecfb3f6c0532f8bea6943","windows/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0-rc0/gaiad-v12.0.0-rc0-windows-arm64.exe?checksum=sha256:833361b453a6ce9e51b964b756bdff4a7a640df40459c6b7cb843937421d327a"}}' \
+--upgrade-info '{"binaries":{"darwin/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-amd64?checksum=sha256:1b76a7b2ee9bd739cd28de6e380248f276c678d8f9cab1fc2fe17fce07389693","darwin/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-arm64?checksum=sha256:20e81d813f942ed3114c6953016b9e24f0946b08e34f0da9c13bcb7276719130","linux/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-amd64?checksum=sha256:d67e91bda37c94f2efacba0f97bcbdb8931e9dbc457d1ce3f1e60a71d1b1b7dd","linux/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-arm64?checksum=sha256:aee279a6aedf8e83e59487c2006e72e496f73c36a882c44b3cc20969c3d237fb","windows/amd64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-amd64.exe?checksum=sha256:7d970cd3f138b5ce8fe78a8209a5907fcfec6fb717434244010381cdd6b4cd32","windows/arm64":"https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-arm64.exe?checksum=sha256:b54c9c7e1c7bb36fc78cac294d86f8836e2dc02d747abc84d68062615a0512df"}}' \
 --description "Upgrade Gaia to v12" \
 --gas auto \
 --fees 1000uatom \

--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v11.0.0` (upgraded from v10 at height `17107825`)
+- **Current Gaia Version:** `v12.0.0-rc0` (upgraded from v11 at height `17550150`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
@@ -110,7 +110,7 @@ Run either one of the scripts provided in this repo to join the provider chain:
 
 If you want to use Cosmovisor's **auto-download** feature, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=true`
 
-If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v12.0.0-rc0 binary to the v12 upgrade directory in your cosmovisor directory (`upgrades/v12/bin/gaiad`). 
+If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v13.0.0-rc0 binary to the v13 upgrade directory in your cosmovisor directory (`upgrades/v13/bin/gaiad`). 
 
 ```
 .
@@ -119,7 +119,7 @@ If you are **manually preparing your binary**, please set the environment variab
 │   └── bin
 │       └── gaiad
 └── upgrades
-    └── v12
+    └── v13
         ├── bin
         │   └── gaiad
         └── upgrade-info.json

--- a/public/UPGRADES.md
+++ b/public/UPGRADES.md
@@ -6,7 +6,7 @@
 
 | Date         | Testnet plan                                                                                                 |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
-| August 23 2023 | [Gaia v12.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v12.0.0-rc0) is live on the testnet           |
+| August 23 2023 | ✅ [Gaia v12.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v12.0.0-rc0) is live on the testnet           |
 | August 21 2023 | ✅ Submit and pass v12 software upgrade [proposal](https://explorer.theta-testnet.polypore.xyz/proposals/176) |
 
 * **Version before upgrade**: `v11.0.0`
@@ -15,7 +15,8 @@
 ### Upgrade details
 
 * **Upgrade height: `17550150`**
-* Estimated upgrade time: `2023-08-23 13:30:00 UTC`
+* Upgrade time: `2023-08-23 13:41:37 UTC`
+  * The upgrade took six minutes, and block `17550152` was indexed at `13:47:33 UTC`
 
 ## v11
 

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-GAIA_VERSION=v11.0.0
+GAIA_VERSION=v12.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
@@ -86,7 +86,7 @@ cp $(which $CHAIN_BINARY) $NODE_HOME/cosmovisor/genesis/bin
 
 echo "Installing cosmovisor..."
 BINARY=$NODE_HOME/cosmovisor/genesis/bin/$CHAIN_BINARY
-go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.3.0
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
 
 sudo rm /etc/systemd/system/$SERVICE_NAME.service
 sudo touch /etc/systemd/system/$SERVICE_NAME.service
@@ -96,10 +96,9 @@ echo "Description=Cosmovisor service"       | sudo tee /etc/systemd/system/$SERV
 echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "User=$USER"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "User=$USER"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "ExecStart=$HOME/go/bin/cosmovisor run start --x-crisis-skip-assert-invariants --home $NODE_HOME --p2p.seeds $SEEDS" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "Restart=always"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "RestartSec=3"                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Restart=no"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "Environment='DAEMON_NAME=$CHAIN_BINARY'"      | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "Environment='DAEMON_HOME=$NODE_HOME'" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-GAIA_VERSION=v11.0.0
+GAIA_VERSION=v12.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom
@@ -83,14 +83,13 @@ sudo rm /etc/systemd/system/$SERVICE_NAME.service
 sudo touch /etc/systemd/system/$SERVICE_NAME.service
 
 echo "[Unit]"                               | sudo tee /etc/systemd/system/$SERVICE_NAME.service
-echo "Description=Gaia service"       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Description=Gaia service"             | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "User=$USER"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "User=$USER"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "ExecStart=$HOME/go/bin/$CHAIN_BINARY start --x-crisis-skip-assert-invariants --home $NODE_HOME --p2p.seeds $SEEDS" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "Restart=always"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "RestartSec=3"                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Restart=no"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Install]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a

--- a/replicated-security/SCHEDULE.md
+++ b/replicated-security/SCHEDULE.md
@@ -5,7 +5,7 @@
 | September 13  2023 |                       |                                                                                                                              |
 | September 6  2023  | Consumer addition     | Consumer chain `grand-rehearsal-1` to be created                                                                             |
 | August 30  2023    |                       |                                                                                                                              |
-| August 23  2023    | Major upgrade         | Provider chain upgrades to Gaia `v12.0.0-rc0`                                                                                |
+| August 23  2023    | Major upgrade         | ✅ Provider chain upgraded to Gaia `v12.0.0-rc0`                                                                              |
 | August 21  2023    | Major upgrade         | ✅ [Proposal](https://explorer.rs-testnet.polypore.xyz/provider/gov/48) to upgrade provider chain to Gaia v12 passes          |
 | August 16  2023    |                       |                                                                                                                              |
 | August 9  2023     |                       |                                                                                                                              |

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -5,20 +5,11 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 * **Chain-ID**: `provider`
 * **denom**: `uatom`
-* **Current Gaia Version**: [`v11.0.0`](https://github.com/cosmos/gaia/releases/tag/v11.0.0), upgraded from v10 at block height `2532935`.
+* **Current Gaia Version**: [`v12.0.0-rc0`](https://github.com/cosmos/gaia/releases/tag/v12.0.0-rc0), upgraded from v11 at block height `2929050`.
 * **Genesis File:**  [provider-genesis.json](provider-genesis.json), verify with `shasum -a 256 provider-genesis.json`
 * **Genesis sha256sum**: `91870bfb8671f5d60c303f9da8e44b620a5403f913359cc6b212150bfc3e631d`
 * Launch Date: 2023-02-02
 * Launch Gaia Version: [`v9.0.0-rc2`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc2)
-
-## v12 Upgrade
-
-The provider chain will upgrade to Gaia [v12.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v12.0.0-rc0) on **Wednesday, August 23 2023**.
-
-* **Block height: `2929050`**
-  * Target upgrade time: `2023-08-23 14:00:00 UTC`
-* [Proposal #48](https://explorer.rs-testnet.polypore.xyz/provider/gov/48)
-* Golang version: 1.20
 
 ## Endpoints
 
@@ -125,4 +116,5 @@ Run the script, and then follow the procedure below to upgrade to the latest ver
 * When the node reaches height `1534600`, stop the service.
 * Replace the `v9.0.0-rc6` binary with the `v9.1.0` one in `~/go/bin`, or `~/.gaia/cosmovisor/current/bin` if you are using Cosmovisor.
 * When the node reaches height `1634770`, it will attempt to upgrade to Gaia `v10`. You can use Cosmovisor's auto-download feature or install the `v10.0.0-rc0` release binary.
-* When the node reaches height `2532935`, it will attempt to upgrade to Gaia `v11`. You can use Cosmovisor's auto-download feature or install the `v11.0.0-rc0` release binary
+* When the node reaches height `2532935`, it will attempt to upgrade to Gaia `v11`. You can use Cosmovisor's auto-download feature or install the `v11.0.0-rc0` release binary.
+* When the node reaches height `2929050`, it will attempt to upgrade to Gaia `v12`. You can use Cosmovisor's auto-download feature or install the `v12.0.0-rc0` release binary.

--- a/replicated-security/provider/join-rs-provider-cv.sh
+++ b/replicated-security/provider/join-rs-provider-cv.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=cv-provider
-GAIA_VERSION=v11.0.0
+GAIA_VERSION=v12.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***
@@ -100,7 +100,7 @@ cp $(which $CHAIN_BINARY) $NODE_HOME/cosmovisor/genesis/bin
 
 echo "Installing cosmovisor..."
 export BINARY=$NODE_HOME/cosmovisor/genesis/bin/$CHAIN_BINARY
-go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.3.0
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
 
 sudo rm /etc/systemd/system/$SERVICE_NAME.service
 sudo touch /etc/systemd/system/$SERVICE_NAME.service

--- a/replicated-security/provider/join-rs-provider.sh
+++ b/replicated-security/provider/join-rs-provider.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=provider
-GAIA_VERSION=v11.0.0
+GAIA_VERSION=v12.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***
@@ -97,13 +97,13 @@ sudo rm /etc/systemd/system/$SERVICE_NAME.service
 sudo touch /etc/systemd/system/$SERVICE_NAME.service
 
 echo "[Unit]"                               | sudo tee /etc/systemd/system/$SERVICE_NAME.service
-echo "Description=Gaia service"       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Description=Gaia service"             | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "User=$USER"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "User=$USER"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "ExecStart=$HOME/go/bin/$CHAIN_BINARY start --x-crisis-skip-assert-invariants --home $NODE_HOME" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "Restart=no"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "Restart=no"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Install]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a


### PR DESCRIPTION
Updated the following:
* Release testnet upgrades, readme, and scripts
* RS testnet schedule, provider chain readme and scripts
* Local testnet upgrade instructions use v12.0.0