### PR TITLE
Gaia v13 upgrade complete

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -8,7 +8,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 
 - **Chain-ID**: `theta-testnet-001`
 - **Launch date**: 2022-03-10
-- **Current Gaia Version:** `v12.0.0` (upgraded from v11 at height `17550150`)
+- **Current Gaia Version:** `v13.0.0-rc0` (upgraded from v11 at height `17550150`)
 - **Launch Gaia Version:** `release/v6.0.0`
 - **Genesis File:**  Zipped and included [in this repository](genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
@@ -110,7 +110,7 @@ Run either one of the scripts provided in this repo to join the provider chain:
 
 If you want to use Cosmovisor's **auto-download** feature, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=true`
 
-If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v13.0.0-rc0 binary to the v13 upgrade directory in your cosmovisor directory (`upgrades/v13/bin/gaiad`). 
+If you are **manually preparing your binary**, please set the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and download a copy of the v14.0.0-rc0 binary to the v14 upgrade directory in your cosmovisor directory (`upgrades/v14/bin/gaiad`). 
 
 ```
 .
@@ -119,7 +119,7 @@ If you are **manually preparing your binary**, please set the environment variab
 │   └── bin
 │       └── gaiad
 └── upgrades
-    └── v13
+    └── v14
         ├── bin
         │   └── gaiad
         └── upgrade-info.json

--- a/public/UPGRADES.md
+++ b/public/UPGRADES.md
@@ -4,9 +4,9 @@
 
 ### Schedule
 
-| Date                | Testnet plan                                  |
-| ------------------- | --------------------------------------------- |
-| September 20 2023   | Gaia v13.0.0-rc0 is live on the testnet       |
+| Date                 | Testnet plan                                  |
+| -------------------  | --------------------------------------------- |
+| ✅ September 20 2023 | Gaia v13.0.0-rc0 is live on the testnet       |
 | ✅ September 18 2023 | Submit and pass v13 software upgrade proposal |
 
 * **Version before upgrade**: `v12.0.0`
@@ -15,8 +15,8 @@
 ### Upgrade details
 
 * **Upgrade height: `17996550`**
-  * Mintscan countdown: https://testnet.mintscan.io/cosmoshub-testnet/blocks/17996550
-* Estimated upgrade time: `2023-09-20 13:30:00 UTC`
+* Upgrade time: `2023-09-20 13:42:06 UTC`
+  * The upgrade took one minute, and block `17996552` was indexed at `13:42:59 UTC`
   
 ## v12
 

--- a/public/join-public-testnet-cv.sh
+++ b/public/join-public-testnet-cv.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=cosmovisor
-GAIA_VERSION=v12.0.0
+GAIA_VERSION=v13.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom

--- a/public/join-public-testnet.sh
+++ b/public/join-public-testnet.sh
@@ -7,7 +7,7 @@
 NODE_HOME=~/.gaia
 NODE_MONIKER=public-testnet
 SERVICE_NAME=gaiad
-GAIA_VERSION=v12.0.0
+GAIA_VERSION=v13.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 GAS_PRICE=0.0025uatom

--- a/replicated-security/provider/README.md
+++ b/replicated-security/provider/README.md
@@ -5,20 +5,11 @@ The provider chain functions as an analogue of the Cosmos Hub. Its governance pa
 
 * **Chain-ID**: `provider`
 * **denom**: `uatom`
-* **Current Gaia Version**: [`v12.0.0`](https://github.com/cosmos/gaia/releases/tag/v12.0.0), upgraded from v11 at block height `2929050`.
+* **Current Gaia Version**: [`v13.0.0-rc0`](https://github.com/cosmos/gaia/releases/tag/v13.0.0-rc0), upgraded from v11 at block height `3313600`.
 * **Genesis File:**  [provider-genesis.json](provider-genesis.json), verify with `shasum -a 256 provider-genesis.json`
 * **Genesis sha256sum**: `91870bfb8671f5d60c303f9da8e44b620a5403f913359cc6b212150bfc3e631d`
 * Launch Date: 2023-02-02
 * Launch Gaia Version: [`v9.0.0-rc2`](https://github.com/cosmos/gaia/releases/tag/v9.0.0-rc2)
-
-## v13 Upgrade
-
-The provider chain will upgrade to Gaia [v13.0.0-rc0](https://github.com/cosmos/gaia/releases/tag/v13.0.0-rc0) on **Wednesday, September 20 2023**.
-
-* **Block height: `3313600`**
-  * Target upgrade time: `2023-09-20 14:00:00 UTC`
-* [Proposal #50](https://explorer.rs-testnet.polypore.xyz/provider/gov/50)
-* Golang version: 1.20
 
 ## Endpoints
 
@@ -121,3 +112,4 @@ Run the script, and then follow the procedure below to upgrade to the latest ver
 * When the node reaches height `1634770`, it will attempt to upgrade to Gaia `v10`. You can use Cosmovisor's auto-download feature or install the `v10.0.0-rc0` release binary.
 * When the node reaches height `2532935`, it will attempt to upgrade to Gaia `v11`. You can use Cosmovisor's auto-download feature or install the `v11.0.0-rc0` release binary.
 * When the node reaches height `2929050`, it will attempt to upgrade to Gaia `v12`. You can use Cosmovisor's auto-download feature or install the `v12.0.0-rc0` release binary.
+* When the node reaches height `3313600`, it will attempt to upgrade to Gaia `v13`. You can use Cosmovisor's auto-download feature or install the `v13.0.0-rc0` release binary.

--- a/replicated-security/provider/join-rs-provider-cv.sh
+++ b/replicated-security/provider/join-rs-provider-cv.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=cv-provider
-GAIA_VERSION=v12.0.0
+GAIA_VERSION=v13.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***

--- a/replicated-security/provider/join-rs-provider.sh
+++ b/replicated-security/provider/join-rs-provider.sh
@@ -16,7 +16,7 @@ NODE_KEY_FILE=~/node_key.json
 NODE_HOME=~/.gaia
 NODE_MONIKER=provider
 SERVICE_NAME=provider
-GAIA_VERSION=v12.0.0
+GAIA_VERSION=v13.0.0-rc0
 CHAIN_BINARY_URL=https://github.com/cosmos/gaia/releases/download/$GAIA_VERSION/gaiad-$GAIA_VERSION-linux-amd64
 STATE_SYNC=true
 # ***


### PR DESCRIPTION
Release testnet and RS testnet (`provider` chain) upgraded to v13.0.0-rc0