### PR TITLE
Update Aether rehearsal network

### DIFF
--- a/replicated-security/ethera_9000-1/consumer-addition-proposal.sh
+++ b/replicated-security/ethera_9000-1/consumer-addition-proposal.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export ACCOUNT="cosmos14wlynjafz3sx48ga0prrwp8e43gugeunurfrc5"
+gaiad tx gov submit-proposal consumer-addition ./proposal-ethera_9000-1.json \
+    --node https://rpc.provider-sentry-01.rs-testnet.polypore.xyz:443 \
+    --from=$ACCOUNT \
+    --chain-id=provider \
+    --gas-prices 0.005uatom --gas auto --gas-adjustment 1.5 \
+    -y

--- a/replicated-security/ethera_9000-1/create-ccv-genesis.sh
+++ b/replicated-security/ethera_9000-1/create-ccv-genesis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gaiad --node https://rpc.provider-sentry-01.rs-testnet.polypore.xyz:443 query provider consumer-genesis ethera_9000-1 -o json > ccv.json
+jq -s '.[0].app_state.ccvconsumer = .[1] | .[0]' ethera_9000-1-genesis-without-ccv.json ccv.json > ethera_9000-1-genesis.json
+rm ccv.json
+sha256sum ethera_9000-1-genesis.json

--- a/replicated-security/ethera_9000-1/proposal-ethera_9000-1.json
+++ b/replicated-security/ethera_9000-1/proposal-ethera_9000-1.json
@@ -1,6 +1,6 @@
 {
   "title": "ethera_9000-1 Chain",
-  "description": "# Launching the ethera_9000-1 Chain\r\n\r\nThis is the proposal to create the first persistent consumer chain, \"ethera_9000-1\".\r\n\r\nPlease visit the [cosmos/testnets](https://github.com/cosmos/testnets/tree/master/replicated-security) repo for additional details.",
+  "description": "# Launching the ethera_9000-1 Chain\r\n\r\nThis is the proposal to create the first consumer chain, \"ethera_9000-1\".\r\n\r\nPlease visit the [cosmos/testnets](https://github.com/cosmos/testnets/tree/master/replicated-security) repo for additional details.",
   "chain_id": "ethera_9000-1",
   "initial_height": {
     "revision_height": 1,

--- a/replicated-security/ethera_9000-1/validators_start_guide.md
+++ b/replicated-security/ethera_9000-1/validators_start_guide.md
@@ -1,0 +1,73 @@
+
+# [Aether - Ethera_9000-1] Validators start guide
+
+## TL;DR
+
+Ethera should join ICS Testnet on `2024-01-17T14:00:00.000000000Z`. 
+This is a small guide to help validators to join Ethera:
+- For launching consumer chains, validators have two main responsibilities:
+  - Submit an `AssignConsumerKey` transaction on the provider chain (more information on [Key Assignment](https://cosmos.github.io/interchain-security/features/key-assignment))
+  - Run the consumer chain binary at the spawn time
+    - **Important to note that Ethera requires the --chain-id flag to be passed on start**
+
+## Starting Ethera (After spawn time)
+
+Once we pass the spawn time, Ethera can be started.
+The best way of starting Ethera is to use our scripts provided on [Testnets](https://github.com/cosmos/testnets):
+- [join_ethera_9000-1_cv.sh](https://github.com/cosmos/testnets/blob/master/replicated-security/ethera_9000-1/join_ethera_9000-1_cv.sh)
+  - Binaries are targeting Linux AMD64
+  - This starts the chain with Cosmos Visor as a service
+- [join_ethera_9000-1.sh](https://github.com/cosmos/testnets/blob/master/replicated-security/ethera_9000-1/join_ethera_9000-1.sh)
+  - Binaries are targeting Linux AMD64
+  - This starts the chain without Cosmos Visor as a service
+
+### Starting Ethera manually
+
+To start Ethera manually, you can run this command:
+**Don't forget to pass the --chain-id flag on start**
+
+```sh
+# Download the genesis with ccv
+GENESIS_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/ethera_9000-1/ethera_9000-1-genesis.json
+BINARY_URL=https://github.com/cosmos/testnets/raw/master/replicated-security/ethera_9000-1/aetherd-linux-amd64
+SEEDS="e6830209e30448357e64a77279c5784b0d0232ee@p2p1.ethera.aetherevm.com:26656,88266f83878399bffd8c3d627a1f401cc389b81f@p2p2.ethera.aetherevm.com:26656"
+NODE_HOME=~/.aetherd
+NODE_MONIKER=ethera_9000-1
+CHAIN_BINARY=aetherd
+
+# Install Aetherd binary
+mkdir -p $HOME/go/bin
+sudo wget $BINARY_URL -O $HOME/go/bin/$CHAIN_BINARY
+sudo chmod +x $HOME/go/bin/$CHAIN_BINARY
+export PATH=$PATH:$HOME/go/bin
+
+# Init aether
+aetherd init $NODE_MONIKER --chain-id ethera_9000-1 --home $NODE_HOME
+
+# Copy validator keys
+cp priv_validator_key.json $NODE_HOME/config/priv_validator_key.json
+
+# Prepare seeds
+sed -i -e "/seeds =/ s^= .*^= \"$SEEDS\"^" $NODE_HOME/config/config.toml
+
+# Download and copy genesis
+wget $GENESIS_URL -O genesis.json
+mv genesis.json $NODE_HOME/config/genesis.json
+
+# Start Ethera
+aetherd start --chain-id ethera_9000-1
+```
+
+### Making my node public
+
+If you are preparing a public node, the following script can help you prepare you node to be public on the p2p network:
+
+```sh
+NODE_HOME=~/.aetherd
+
+sed -i -e "/external_address =/ s^= .*^= \"$(curl httpbin.org/ip | jq -r .origin):26656\"^" $NODE_HOME/config/config.toml
+```
+
+## Congratulations!
+
+After that, you should have Aether running on the Ethera network.


### PR DESCRIPTION
This PR contains further files for Aether rehearsal network.

This PR create:
- `validators_start_guide.md`
  - Guide on how to start Aether nodes
- `consumer-addition-proposal.sh` 
  - Script used to create the consumer proposal
- `create-ccv-genesis.sh`
  - This pulls the `ethera_9000-1` ccv and add it to genesis

This PR update:
- `proposal-ethera_9000-1.json`
  - Removes the persistent word from the proposal